### PR TITLE
CircleCI: Report on test results directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,12 @@ jobs:
           name: Tests
           command: pipenv run pytest -v --cov=squeezealexa --cov-report=term tests
 
+      - store_test_results:
+          path: test-results
+
+      - store_artifacts:
+          path: test-results
+
       - run:
           name: Code Quality
           command: pipenv run flake8 --statistics .

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+test-results
+
 
 # Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ exclude_lines =
     def __repr__
     raise NotImplementedError
     if __name__ == .__main__.:
+
+[tool:pytest]
+addopts = --junitxml=test-results/py.test/results.xml


### PR DESCRIPTION
 * Output JUnit XML from pytest
 * Interpret and store these in CircleCI
 * But ignore in Git of course...

Fixes #72