### PR TITLE
Fix relative paths for tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,10 @@ jobs:
           command: bin/deploy.py zip
 
       - run:
+          name: Test deploy script (from source, from dist/bin/)
+          command: cd dist/bin && ./deploy.py zip
+
+      - run:
           name: Test deploy script (without build)
           command: rm -rf dist/ tests/ && bin/deploy.py zip
 

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -27,7 +27,7 @@ from zipfile import ZipFile, ZIP_DEFLATED, ZipInfo
 import boto3
 from botocore.exceptions import ClientError
 
-ROOT = realpath(dirname(dirname(__file__)))
+ROOT = dirname(dirname(realpath(__file__)))
 DIST_SUBDIR = "dist"
 
 OUTPUT_ZIP = path.join(ROOT, "lambda_function.zip")

--- a/bin/local_test.py
+++ b/bin/local_test.py
@@ -11,10 +11,10 @@
 #   See LICENSE for full license
 
 import sys
-from os.path import dirname
+from os.path import dirname, realpath
 from traceback import print_exc
 
-sys.path.append(dirname(dirname(__file__)))
+sys.path.append(dirname(dirname(realpath(__file__))))
 
 from squeezealexa.settings import *
 from squeezealexa.transport.factory import TransportFactory


### PR DESCRIPTION
 * Wasn't working out parent directories properly if you were in `bin/` already.
 * Add a CI loop to at least vaguely test this

Fixes #100